### PR TITLE
Update the V4L2 wrapper to be more compliant with V4L2 UAPI

### DIFF
--- a/v4l2_wrapper.h
+++ b/v4l2_wrapper.h
@@ -102,6 +102,12 @@ void set_device_format(int32_t file_descriptor, uint32_t width, uint32_t height,
     struct v4l2_format format;
     struct v4l2_streamparm parm;
 
+    V4L2_Version current_version = {};
+    if (!read_v4l2_version(&current_version)){
+        fprintf(stderr, "Failed to read the v4l2loopback device's version number.\n");
+        goto fail_and_log;
+    }
+
     if (ioctl(file_descriptor, VIDIOC_QUERYCAP, &capability) < 0) {
         fprintf(stderr, "Failed to query the v4l2loopback device.\n");
         goto fail_and_log;
@@ -135,7 +141,7 @@ void set_device_format(int32_t file_descriptor, uint32_t width, uint32_t height,
         goto fail_and_log;
     }
 
-    if (ioctl(file_descriptor, VIDIOC_STREAMON, &parm) < 0) {
+    if (is_v4l2_version_new(&current_version) && ioctl(file_descriptor, VIDIOC_STREAMON, &parm) < 0) {
         fprintf(stderr, "Failed to start streaming.\n");
         goto fail_and_log;
     }

--- a/v4l2_wrapper.h
+++ b/v4l2_wrapper.h
@@ -14,6 +14,20 @@
 
 #include "defines.h"
 
+typedef struct {
+    uint32_t major;
+    uint32_t minor;
+    uint32_t bugfix;
+} V4L2_Version;
+
+const V4L2_Version NEW_STANDARD_VERSION = {
+        .major = 0,
+        .minor = 13,
+        .bugfix = 2
+};
+
+const char *V4L2_LOOPBACK_MODULE_VERSION_LOCATION = "/sys/module/v4l2loopback/version";
+
 int32_t open_device(const int32_t output_device) {
     // /dev/video###
     char device_location[13];


### PR DESCRIPTION
v4l2loopback contained a bug that required the use of invalid streaming caps, but with version 0.13.2 that's no longer the case. This PR fixes that.