### PR TITLE
Capture SDK 9.0 / NVFBC 1.9: Wayland (PipeWire), portal token & Vulkan/direct backends

### DIFF
--- a/NvFBC.h
+++ b/NvFBC.h
@@ -4,7 +4,7 @@
  * This file contains the interface constants, structure definitions and
  * function prototypes defining the NvFBC API for Linux.
  *
- * Copyright (c) 2013-2020, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2013-2025, NVIDIA CORPORATION. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -77,12 +77,22 @@
  * - xorg-server >= 1.3:
  *   Optional.  Required for push model to work properly.
  *
+ * - libpipewire-0.3.so.0 >= 1.0.0:
+ *   Optional.  Required for the PipeWire capture backend.
+ *
+ * - libdbus-1.so.3 >= 1.14.0:
+ *   Optional.  Required for communicating with XDG Desktop Portal.
+ *
+ * - libdrm.so.2 >= 2.4.110:
+ *   Optional.  But required by the PipeWire capture backend for using DRM syncobjs.
+ *
  * Note that all optional dependencies are dlopen()'d at runtime.  Failure to
  * load an optional library is not fatal.
  */
 
 /*!
  * \defgroup FBC_CHANGES ChangeLog
+ * @{
  *
  * NvFBC Linux API version 0.1
  * - Initial BETA release.
@@ -166,10 +176,45 @@
  * - Added 'bAllowDirectCapture' to NVFBC_CREATE_CAPTURE_SESSION_PARAMS.
  * - Added 'bDirectCaptured' to NVFBC_FRAME_GRAB_INFO.
  * - Added 'bRequiredPostProcessing' to NVFBC_FRAME_GRAB_INFO.
+ *
+ * NvFBC Linux API version 1.9
+ * - Added support for capturing frames from PipeWire, which allows NvFBC to be
+ *   used on Wayland.
+ * - Added 'nvFBCCompositeCursor' API.
+ * - Added 'bCursorVisible' to NVFBC_FRAME_GRAB_INFO.
+ * - Added 'bCursorComposited' to NVFBC_FRAME_GRAB_INFO.
+ * - Added 'bUseEGL' to NVFBC_CREATE_HANDLE_PARAMS.
+ * - Added 'eBackend' to NVFBC_CREATE_HANDLE_PARAMS.
+ * - Added 'portalRestoreToken' to NVFBC_CREATE_HANDLE_PARAMS.
+ * - Added 'portalRestoreToken' to NVFBC_GET_STATUS_PARAMS.
+ * - Added support for the direct capture backend, which allows NvFBC direct
+ *   capture of a Vulkan graphics application by its pid.
+ * - Added 'dwPid' to NVFBC_GET_STATUS_PARAMS.
+ * - Added 'dwDbusTimeoutMs' to NVFBC_GET_STATUS_PARAMS.
+ * - Added 'dwCaptureTargetCount' to NVFBC_GET_STATUS_PARAMS.
+ * - Added 'captureTargetSizes' to NVFBC_GET_STATUS_PARAMS.
+ * - Added 'dwPid' to NVFBC_CREATE_CAPTURE_SESSION_PARAMS.
+ * - Added 'dwDbusTimeoutMs' to NVFBC_CREATE_CAPTURE_SESSION_PARAMS.
+ * - Added 'dwCaptureTarget' to NVFBC_CREATE_CAPTURE_SESSION_PARAMS.
+ * @}
  */
 
 /*!
- * \defgroup FBC_MODES Capture Modes
+ * \defgroup FBC_CAPTURE_BACKENDS
+ * @{
+ *
+ * NvFBC supports multiple capture backends. The capture backend is selected
+ * through NVFBC_CREATE_HANDLE_PARAMS::eBackend.
+ *
+ * NVFBC_BACKEND_AUTO
+ *
+ * Automatically select the backend per the below logic:
+ *   - NVFBC_BACKEND_PIPEWIRE if the XDG_SESSION_TYPE envvar is set to "wayland".
+ *   - Otherwise, NVFBC_BACKEND_X11 if the DISPLAY envvar is set.
+ *   - Otherwise, NVFBC_BACKEND_DIRECT.
+ *
+ *
+ * NVFBC_BACKEND_X11
  *
  * When creating a capture session, NvFBC instantiates a capture subsystem
  * living in the NVIDIA X driver.
@@ -185,7 +230,7 @@
  *
  * NvFBC can also attach itself to a fullscreen unoccluded application and have
  * it copy its frames directly into a buffer owned by NvFBC upon present. This
- * mode bypasses the X server.
+ * mode bypasses the X server for generating the frame.
  * See NVFBC_CREATE_CAPTURE_SESSION_PARAMS::bAllowDirectCapture.
  *
  * NvFBC is designed to capture frames with as few copies as possible. The
@@ -194,6 +239,68 @@
  *
  * Depending on the configuration of a capture session, an extra copy (rendering
  * pass) may be needed. See the 'Post Processing' section.
+ *
+ *
+ * NVFBC_BACKEND_PIPEWIRE
+ *
+ * The PipeWire backend uses the XDG Desktop Portal to request a PipeWire node
+ * from the running compositor. The compositor may show a dialog on the screen
+ * that allows the users to choose the screen they want to record. When NvFBC
+ * has a PipeWire node, it reserves the images received via PipeWire to be
+ * grabbed by the capture session.
+ *
+ * It has the following limitations:
+ *   - Direct capture mode does not have an effect.
+ *   - Since the PipeWire backend does not have a compositor subsystem, push
+ *     model is not supported.
+ *   - Calling NvFBCCompositeCursor() while using this backend is not
+ *     supported. The cursor composition could still be controlled using the
+ *     bWithCursor field of the NVFBC_CREATE_CAPTURE_SESSION_PARAMS struct.
+ *   - NvFBCGetStatus() cannot get the screen size before a capture session is
+ *     created.
+ *   - It is tested on KWin 6.0 and Mutter 46. Other compositors or the earlier
+ *     versions of these compositors are likely incompatible.
+ *
+ *
+ * NVFBC_BACKEND_DIRECT
+ *
+ * The direct capture backend lets an NvFBC client contact a Vulkan application
+ * through its pid via DBus without involving a display server.
+ *
+ * NvFBC uses the system bus and requires the below DBus configuration snippet
+ * in /etc/dbus-1/system.d/nvidia-dbus.conf:
+ *
+ * \verbatim
+ * <busconfig>
+ *   <type>system</type>
+ *   <policy context="default">
+ *     <allow own_prefix="nvidia.nvfbc"/>
+ *     <allow send_requested_reply="true" send_type="method_return"/>
+ *     <allow send_requested_reply="true" send_type="error"/>
+ *     <allow receive_requested_reply="true" receive_type="method_return"/>
+ *     <allow receive_requested_reply="true" receive_type="error"/>
+ *     <allow send_destination_prefix="nvidia.nvfbc"/>
+ *   </policy>
+ * </busconfig>
+ * \endverbatim
+ *
+ * Direct capture works as described in
+ * NVFBC_CREATE_CAPTURE_SESSION_PARAMS::bAllowDirectCapture, except there is no
+ * requirement that the application must be fullscreen. The direct capture
+ * backend can capture occluded applications, provided that they are still
+ * presenting frames.
+ *
+ * The X11, Wayland, and Direct-to-Display Vulkan WSI platforms are supported.
+ * OpenGL applications are not currently supported.
+ *
+ * Note that applications poll DBus messages once per frame. An application not
+ * presenting frames may delay processing DBus requests.
+ *
+ * The direct capture backend has the following limitations:
+ *   - Only supports NVFBC_CREATE_CAPTURE_SESSION_PARAMS::bPushModel.
+ *   - Cannot composite a mouse cursor.
+ *   - Cannot resize frames or capture a subregion.
+ * @}
  */
 
 /*!
@@ -262,7 +369,7 @@ extern "C" {
 /*!
  * NvFBC API minor version.
  */
-#define NVFBC_VERSION_MINOR 8
+#define NVFBC_VERSION_MINOR 9
 
 /*!
  * NvFBC API version.
@@ -381,6 +488,23 @@ typedef enum _NVFBCSTATUS
      * This indicates a Vulkan error.
      */
     NVFBC_ERR_VULKAN          = 17,
+    /*!
+     * This indicates an EGL error.
+     */
+    NVFBC_ERR_EGL             = 18,
+    /*!
+     * This indicates a D-Bus error.
+     */
+    NVFBC_ERR_DBUS            = 19,
+    /*!
+     * This indicates a PipeWire error.
+     */
+    NVFBC_ERR_PIPEWIRE        = 20,
+    /*!
+     * This indicates a DRM (Direct Rendering Manager) error.
+     */
+    NVFBC_ERR_DRM             = 21,
+
 } NVFBCSTATUS;
 
 /*!
@@ -503,6 +627,29 @@ typedef enum _NVFBC_BUFFER_FORMAT
      */
     NVFBC_BUFFER_FORMAT_BGRA,
 } NVFBC_BUFFER_FORMAT;
+
+/*!
+ * Backend type describes the source an NvFBC session receives the frames from.
+ */
+typedef enum _NVFBC_BACKEND
+{
+    /*!
+     * The backend will be selected by NvFBC.
+     */
+    NVFBC_BACKEND_AUTO = 0,
+    /*!
+     * X11 backend will be used.
+     */
+    NVFBC_BACKEND_X11,
+    /*!
+     * PipeWire backend will be used.
+     */
+    NVFBC_BACKEND_PIPEWIRE,
+    /*!
+     * Direct backend will be used.
+     */
+    NVFBC_BACKEND_DIRECT,
+} NVFBC_BACKEND;
 
 #define NVFBC_BUFFER_FORMAT_YUV420P NVFBC_BUFFER_FORMAT_NV12
 
@@ -641,7 +788,25 @@ typedef struct _NVFBC_FRAME_GRAB_INFO
      * See NVFBC_CREATE_CAPTURE_SESSION_PARAMS::bAllowDirectCapture.
      */
     NVFBC_BOOL bDirectCapture;
+    /*
+     * [out] Whether the HW cursor is currently visible.
+     */
+    NVFBC_BOOL bCursorVisible;
+    /*
+     * [out] Whether NvFBC composited the cursor to the frame.
+     */
+    NVFBC_BOOL bCursorComposited;
 } NVFBC_FRAME_GRAB_INFO;
+
+/*!
+ * Maximum size in bytes of an allowed XDG Desktop Portal session restore token.
+ */
+#define NVFBC_PORTAL_RESTORE_TOKEN_LEN 64
+
+/*!
+ * Maximum number of capture targets per application.
+ */
+#define NVFBC_DIRECT_MAX_CAPTURE_TARGETS 10
 
 /*!
  * Defines parameters for the CreateHandle() API call.
@@ -677,8 +842,8 @@ typedef struct _NVFBC_CREATE_HANDLE_PARAMS
     /*!
      * [in] GLX context
      *
-     * GLX context that NvFBC should use internally to create pixmaps and
-     * make them current when creating a new capture session.
+     * GLX context that NvFBC should use to create pixmaps and access OpenGL
+     * entry points.
      *
      * Note: NvFBC expects a context created against a GLX_RGBA_TYPE render
      * type.
@@ -697,12 +862,40 @@ typedef struct _NVFBC_CREATE_HANDLE_PARAMS
      *  GLX_BIND_TO_TEXTURE_TARGETS_EXT, GLX_TEXTURE_2D_BIT_EXT
      */
     void *glxFBConfig;
+    /*!
+     * [in] Whether to use EGL as the OpenGL ICD instead of GLX.
+     *
+     * NvFBC uses the EGL_PLATFORM_DEVICE_EXT extension to create a display
+     * device that has no dependency on X.
+     */
+    NVFBC_BOOL bUseEGL;
+    /*!
+     * [in/out] Backend to be used.
+     *
+     * If a specific backend is not set, NvFBC picks one based on the
+     * information available, and updates this field to indicate the chosen
+     * backend.
+     */
+    NVFBC_BACKEND eBackend;
+    /*!
+     * [in] XDG Desktop Portal session restore token.
+     *
+     * This token allows the PipeWire backend to restore a previously created
+     * XDG Desktop Portal screeencasting session. When a screencasting session
+     * is successfully restored, users do not need to grant permission to the
+     * recording application. If a token is provided here, it will be used to
+     * restore a previously created session by the PipeWire backend. If no
+     * token is provided, a new token will be populated by NvFBC in this field
+     * that can be stored by the user and provided later while creating another
+     * NvFBC capture session.
+     */
+    char portalRestoreToken[NVFBC_PORTAL_RESTORE_TOKEN_LEN];
 } NVFBC_CREATE_HANDLE_PARAMS;
 
 /*!
  * NVFBC_CREATE_HANDLE_PARAMS structure version.
  */
-#define NVFBC_CREATE_HANDLE_PARAMS_VER NVFBC_STRUCT_VERSION(NVFBC_CREATE_HANDLE_PARAMS, 2)
+#define NVFBC_CREATE_HANDLE_PARAMS_VER NVFBC_STRUCT_VERSION(NVFBC_CREATE_HANDLE_PARAMS, 3)
 
 /*!
  * Defines parameters for the ::NvFBCDestroyHandle() API call.
@@ -822,12 +1015,54 @@ typedef struct _NVFBC_GET_STATUS_PARAMS
      * Note that VT-switches are considered modesets.
      */
     NVFBC_BOOL bInModeset;
+    /*!
+     * [out] XDG Desktop Portal session restore token.
+     *
+     * This field is populated with XDG Desktop Portal session restore token
+     * when a screencasting session has been succesfully created. For more
+     * information about this session restore token, see
+     * NVFBC_CREATE_HANDLE_PARAMS::restoreToken.
+     */
+    char portalRestoreToken[NVFBC_PORTAL_RESTORE_TOKEN_LEN];
+    /*!
+     * [in] Pid of a Vulkan application to capture.
+     *
+     * Note that the NVFBC_BACKEND_DIRECT backend must have been requested in
+     * NVFBC_CREATE_HANDLE_PARAMS::eBackend.
+     *
+     * The NvFBC client will contact the Vulkan application through DBus to
+     * establish a direct capture session.
+     */
+    uint32_t dwPid;
+    /*!
+     * [in] Timeout for DBus requests in milliseconds.
+     *
+     * Note that a graphics application processes DBus messages once per frame
+     * presentation. An application not presenting any frame may not respond
+     * to this request.
+     *
+     * Pass -1 for infinite. Default: 1000 ms.
+     */
+    int dwDbusTimeoutMs;
+    /*!
+     * [out] Number of targets that can be captured through direct capture.
+     *
+     * Corresponds to the number capture targets owned by the application's
+     * given pid, up to NVFBC_DIRECT_MAX_CAPTURE_TARGETS.
+     */
+    uint32_t dwCaptureTargetCount;
+    /*!
+     * [out] Size of the targets that can be captured through direct capture.
+     *
+     * Corresponds to the targets owned by the application's given pid.
+     */
+    NVFBC_SIZE captureTargetSizes[NVFBC_DIRECT_MAX_CAPTURE_TARGETS];
 } NVFBC_GET_STATUS_PARAMS;
 
 /*!
  * NVFBC_GET_STATUS_PARAMS structure version.
  */
-#define NVFBC_GET_STATUS_PARAMS_VER NVFBC_STRUCT_VERSION(NVFBC_GET_STATUS_PARAMS, 2)
+#define NVFBC_GET_STATUS_PARAMS_VER NVFBC_STRUCT_VERSION(NVFBC_GET_STATUS_PARAMS, 4)
 
 /*!
  * Defines parameters for the ::NvFBCCreateCaptureSession() API call.
@@ -876,6 +1111,10 @@ typedef struct _NVFBC_CREATE_CAPTURE_SESSION_PARAMS
      *
      * Disabling the cursor will not generate new frames when only the cursor
      * is moved.
+     *
+     * Can be modified at runtime with the ::nvFBCCompositeCursor() API.
+     *
+     * The cursor is only composited if visible.
      */
     NVFBC_BOOL bWithCursor;
     /*!
@@ -965,7 +1204,6 @@ typedef struct _NVFBC_CREATE_CAPTURE_SESSION_PARAMS
      * Direct capture is possible under the following conditions:
      * - Direct capture is allowed
      * - Push model is enabled (see NVFBC_CREATE_CAPTURE_SESSION_PARAMS::bPushModel)
-     * - The mouse cursor is not composited (see NVFBC_CREATE_CAPTURE_SESSION_PARAMS::bWithCursor)
      * - No viewport transformation is required. This happens when the remote
      *   desktop is e.g. rotated.
      *
@@ -990,12 +1228,36 @@ typedef struct _NVFBC_CREATE_CAPTURE_SESSION_PARAMS
      * direct capture by checking NVFBC_FRAME_GRAB_INFO::bDirectCapture.
      */
     NVFBC_BOOL bAllowDirectCapture;
+    /*!
+     * [in] Pid of a Vulkan application to capture.
+     *
+     * Note that the NVFBC_BACKEND_DIRECT backend must have been requested in
+     * NVFBC_CREATE_HANDLE_PARAMS::eBackend.
+     *
+     * The NvFBC client will contact the Vulkan application through DBus to
+     * establish a direct capture session.
+     */
+    uint32_t dwPid;
+    /*!
+     * [in] Timeout for DBus requests in milliseconds.
+     *
+     * Note that a graphics application processes DBus messages once per frame
+     * presentation. An application not presenting any frame may not respond
+     * to this request.
+     *
+     * Pass -1 for infinite. Default: 1000 ms.
+     */
+    int dwDbusTimeoutMs;
+    /*!
+     * [in] Index of the target to capture.
+     */
+    uint32_t dwCaptureTarget;
 } NVFBC_CREATE_CAPTURE_SESSION_PARAMS;
 
 /*!
  * NVFBC_CREATE_CAPTURE_SESSION_PARAMS structure version.
  */
-#define NVFBC_CREATE_CAPTURE_SESSION_PARAMS_VER NVFBC_STRUCT_VERSION(NVFBC_CREATE_CAPTURE_SESSION_PARAMS, 6)
+#define NVFBC_CREATE_CAPTURE_SESSION_PARAMS_VER NVFBC_STRUCT_VERSION(NVFBC_CREATE_CAPTURE_SESSION_PARAMS, 7)
 
 /*!
  * Defines parameters for the ::NvFBCDestroyCaptureSession() API call.
@@ -1515,6 +1777,26 @@ typedef struct _NVFBC_TOGL_GRAB_FRAME_PARAMS
  */
 #define NVFBC_TOGL_GRAB_FRAME_PARAMS_VER NVFBC_STRUCT_VERSION(NVFBC_TOGL_GRAB_FRAME_PARAMS, 2)
 
+/*!
+ * Defines parameters for the ::NvFBCCompositeCursor() API call.
+ */
+typedef struct _NVFBC_COMPOSITE_CURSOR_FRAME
+{
+    /*!
+     * [in] Must be set to NVFBC_COMPOSITE_CURSOR_PARAMS_VER.
+     */
+    uint32_t dwVersion;
+    /*!
+     * [in] Whether the mouse cursor should be composited to captured frames.
+     */
+    NVFBC_BOOL bWithCursor;
+} NVFBC_COMPOSITE_CURSOR_PARAMS;
+
+/*!
+ * NVFBC_COMPOSITE_CURSOR_PARAMS structure version.
+ */
+#define NVFBC_COMPOSITE_CURSOR_PARAMS_VER NVFBC_STRUCT_VERSION(NVFBC_COMPOSITE_CURSOR_PARAMS, 1)
+
 /*! @} FBC_STRUCT */
 
 /*!
@@ -1923,6 +2205,28 @@ NVFBCSTATUS NVFBCAPI NvFBCToGLSetUp(const NVFBC_SESSION_HANDLE sessionHandle, NV
 NVFBCSTATUS NVFBCAPI NvFBCToGLGrabFrame(const NVFBC_SESSION_HANDLE sessionHandle, NVFBC_TOGL_GRAB_FRAME_PARAMS *pParams);
 
 /*!
+ * \brief Requests whether the mouse cursor should be composited to captured frames.
+ *
+ * This is equivalent to changing the value of NVFBC_CREATE_CAPTURE_SESSION_PARAMS::bWithCursor
+ * on an existing capture session.
+ *
+ * \param [in] sessionHandle
+ *   FBC session handle.
+ *
+ * \param [in] pParams
+ *   ::NVFBC_COMPOSITE_CURSOR_PARAMS
+ *
+ * \return
+ *   ::NVFBC_SUCCESS \n
+ *   ::NVFBC_ERR_INVALID_HANDLE \n
+ *   ::NVFBC_ERR_API_VERSION \n
+ *   ::NVFBC_ERR_BAD_REQUEST \n
+ *   ::NVFBC_ERR_CONTEXT \n
+ *   ::NVFBC_ERR_INTERNAL
+ */
+NVFBCSTATUS NVFBCAPI NvFBCCompositeCursor(const NVFBC_SESSION_HANDLE sessionHandle, NVFBC_COMPOSITE_CURSOR_PARAMS *pParams);
+
+/*!
  * \cond FBC_PFN
  *
  * Defines API function pointers
@@ -1941,6 +2245,7 @@ typedef NVFBCSTATUS (NVFBCAPI* PNVFBCTOCUDASETUP)(const NVFBC_SESSION_HANDLE ses
 typedef NVFBCSTATUS (NVFBCAPI* PNVFBCTOCUDAGRABFRAME)(const NVFBC_SESSION_HANDLE sessionHandle, NVFBC_TOCUDA_GRAB_FRAME_PARAMS *pParams);
 typedef NVFBCSTATUS (NVFBCAPI* PNVFBCTOGLSETUP)(const NVFBC_SESSION_HANDLE sessionHandle, NVFBC_TOGL_SETUP_PARAMS *pParams);
 typedef NVFBCSTATUS (NVFBCAPI* PNVFBCTOGLGRABFRAME)(const NVFBC_SESSION_HANDLE sessionHandle, NVFBC_TOGL_GRAB_FRAME_PARAMS *pParams);
+typedef NVFBCSTATUS (NVFBCAPI* PNVFBCCOMPOSITECURSOR)(const NVFBC_SESSION_HANDLE sessionHandle, NVFBC_COMPOSITE_CURSOR_PARAMS *pParams);
 
 /// \endcond
 
@@ -1975,6 +2280,7 @@ typedef struct
     void*                                     pad7;                       //!< [out] Retired. Do not use.
     PNVFBCTOGLSETUP                           nvFBCToGLSetUp;             //!< [out] Pointer to ::nvFBCToGLSetup().
     PNVFBCTOGLGRABFRAME                       nvFBCToGLGrabFrame;         //!< [out] Pointer to ::nvFBCToGLGrabFrame().
+    PNVFBCCOMPOSITECURSOR                     nvFBCCompositeCursor;       //!< [out] Pointer to ::nvFBCCompositeCursor().
 } NVFBC_API_FUNCTION_LIST;
 
 /*!

--- a/README.md
+++ b/README.md
@@ -9,10 +9,16 @@ _**Because why not? It's better than nothing!**_
 
 ## Requirements:
 
-* **A Nvidia GPU that supports NvFBC.** _(if it wasn't obvious)_
+* **An NVIDIA GPU that supports NvFBC.** _(if it wasn't obvious)_
 * **A Linux Desktop with CMake and GCC installed.**
-* **Proprietary Nvidia Drivers.** _(maybe. I haven't tested it with the open-source drivers yet)_
-* **X11 as a display server.**
+* **Nvidia drivers with NvFBC 1.9 / Capture SDK 9.0** _(recent proprietary or open kernel-module drivers)._
+* **X11 _or_ Wayland.** Wayland capture goes through PipeWire and the XDG Desktop Portal.
+
+Optional, only needed for the non-X11 backends. NvFBC `dlopen()`s these itself at
+runtime, so you do **not** link them yourself:
+
+* `libpipewire-0.3.so.0` (>= 1.0.0) and `libdbus-1.so.3` (>= 1.14.0) — the Wayland/PipeWire backend.
+* `libdrm.so.2` (>= 2.4.110) — used by the PipeWire backend for DRM syncobjs.
 
 ----
 
@@ -79,6 +85,64 @@ $ ./nvfbc-v4l2 -o [v4l2-nr] -s [screen]
 If the capture appears corrupted, try removing the v4l2loopback module and
 adding it again with the commands above. If that doesn't help, open up an issue,
 and I'll try my best to help. **Remember to close the program while doing this.**
+
+----
+
+## Backends
+
+NvFBC 1.9 can capture through three backends, selected with `-b` / `--backend`:
+
+| Backend    | Use case                                    | Notes |
+|------------|---------------------------------------------|-------|
+| `auto`     | Default. Picks one based on your session.   | Wayland → `pipewire`, else X11 → `x11`, else `direct`. |
+| `x11`      | Classic X11 desktop capture.                | Per-output selection with `-s`, push model supported. |
+| `pipewire` | Wayland capture via the XDG Desktop Portal. | The compositor shows a screen-picker dialog. |
+| `direct`   | Capture a single Vulkan app by its pid.     | No display server required. |
+
+### Wayland (PipeWire)
+
+```shell
+$ ./nvfbc-v4l2 -b pipewire -o 3
+```
+
+On the first run your compositor pops up a screen-picker / permission dialog
+(tested on KWin 6 and Mutter 46). NvFBC then returns a *portal restore token*,
+saved to `~/.cache/nvfbc-v4l2/portal.token` (override with `--portal-token <path>`).
+Subsequent runs reuse that token and skip the dialog. Pass `--new-token` to ignore
+the saved token and force a fresh session (and the picker dialog); the new session's
+token then replaces the saved one.
+
+`-s`/`--screen` does not apply here — the compositor's dialog picks the screen.
+
+### Capturing a Vulkan application (direct)
+
+The direct backend attaches to a single Vulkan application by pid over D-Bus,
+without any display server. It first needs this D-Bus policy installed at
+`/etc/dbus-1/system.d/nvidia-dbus.conf`:
+
+```xml
+<busconfig>
+  <type>system</type>
+  <policy context="default">
+    <allow own_prefix="nvidia.nvfbc"/>
+    <allow send_requested_reply="true" send_type="method_return"/>
+    <allow send_requested_reply="true" send_type="error"/>
+    <allow receive_requested_reply="true" receive_type="method_return"/>
+    <allow receive_requested_reply="true" receive_type="error"/>
+    <allow send_destination_prefix="nvidia.nvfbc"/>
+  </policy>
+</busconfig>
+```
+
+Then list the application's capture targets and capture one:
+
+```shell
+$ ./nvfbc-v4l2 -P <pid> -l            # list the capture targets owned by that pid
+$ ./nvfbc-v4l2 -P <pid> -t 0 -o 3     # capture target 0 into /dev/video3
+```
+
+Per NvFBC, the direct backend is push-model only, cannot composite a cursor, and
+cannot resize or capture a sub-region.
 
 # Special Thanks To:
 

--- a/main.c
+++ b/main.c
@@ -1,11 +1,18 @@
 #include <stdio.h>
 #include <getopt.h>
+#include <math.h>
 #include <signal.h>
 
 #include "v4l2_wrapper.h"
 #include "nvfbc_v4l2.h"
 #include "xrandr_wrapper.h"
 #include "pixel_fmt_tools.h"
+
+// these are placeholders for non-existent ASCII codes
+enum {
+    OPT_PORTAL_TOKEN = 1000,
+    OPT_NEW_TOKEN    = 1001
+};
 
 static bool quit_program = false;
 
@@ -22,6 +29,24 @@ enum Pixel_Format string_to_pixel_fmt(const char* string) {
     strcmp(string, "yuv420") == 0 ? YUV_420 :
     strcmp(string, "rgba") == 0 ? RGBA_444 :
     strcmp(string, "nv12") == 0 ? NV_12 : Pixel_Fmt_None;
+}
+
+// Returns the requested backend, or (NVFBC_BACKEND) -1 for an unknown name.
+static NVFBC_BACKEND string_to_backend(const char* string) {
+    return
+    strcmp(string, "auto") == 0 ? NVFBC_BACKEND_AUTO :
+    strcmp(string, "x11") == 0 ? NVFBC_BACKEND_X11 :
+    strcmp(string, "pipewire") == 0 ? NVFBC_BACKEND_PIPEWIRE :
+    strcmp(string, "direct") == 0 ? NVFBC_BACKEND_DIRECT : (NVFBC_BACKEND) -1;
+}
+
+static const char* backend_name(const NVFBC_BACKEND backend) {
+    switch (backend) {
+        case NVFBC_BACKEND_X11:      return "X11";
+        case NVFBC_BACKEND_PIPEWIRE: return "PipeWire (Wayland)";
+        case NVFBC_BACKEND_DIRECT:   return "Direct (Vulkan)";
+        default:                     return "auto";
+    }
 }
 
 uint32_t get_pixel_buffer_size(const uint32_t width, const uint32_t height, const enum Pixel_Format pixel_fmt) {
@@ -42,8 +67,8 @@ uint32_t get_pixel_buffer_size(const uint32_t width, const uint32_t height, cons
     }
 }
 
-void yuv420_loop(void** frame_ptr, NvFBC_InitData nvfbc_data, int32_t v4l2_device, uint32_t buffer_size, const NvFBC_SessionData* session_pointer, YUV_420_Data** yuv_data, Capture_Settings* capture_settings);
-void normal_loop(void** frame_ptr, int32_t v4l2_device, uint32_t buffer_size, const NvFBC_SessionData* session_pointer, Capture_Settings* capture_settings);
+void yuv420_loop(void** frame_ptr, uint32_t width, uint32_t height, int32_t v4l2_device, uint32_t buffer_size, const NvFBC_SessionData* session_pointer, YUV_420_Data** yuv_data, const Capture_Settings* capture_settings);
+void normal_loop(void** frame_ptr, int32_t v4l2_device, uint32_t buffer_size, const NvFBC_SessionData* session_pointer, const Capture_Settings* capture_settings);
 
 int main(const int argc, char* const argv[]) {
     bool list = false;
@@ -54,7 +79,12 @@ int main(const int argc, char* const argv[]) {
             .push_model = true,
             .direct_capture = false,
             .show_cursor = true,
-            .fps = 60
+            .fps = 60,
+            .backend = NVFBC_BACKEND_AUTO,
+            .vulkan_pid = 0,
+            .vulkan_target_index = 0,
+            .xdg_portal_token_path = NULL,
+            .issue_new_xdg_token = false
     };
 
     enum Pixel_Format pixel_fmt = RGB_24;
@@ -64,6 +94,11 @@ int main(const int argc, char* const argv[]) {
             {"screen",         required_argument, NULL, 's'},
             {"pixel-format",   required_argument, NULL, 'p'},
             {"fps",            required_argument, NULL, 'f'},
+            {"backend",        required_argument, NULL, 'b'},
+            {"pid",            required_argument, NULL, 'P'},
+            {"target",         required_argument, NULL, 't'},
+            {"portal-token",   required_argument, NULL, OPT_PORTAL_TOKEN},
+            {"new-token",      no_argument,       NULL, OPT_NEW_TOKEN},
             {"stdout",         no_argument,       NULL, 'r'},
             {"no-push-model",  no_argument,       NULL, 'n'},
             {"direct-capture", no_argument,       NULL, 'd'},
@@ -76,7 +111,7 @@ int main(const int argc, char* const argv[]) {
     // shortopts explained
     // after each .val you can notice a ':'
     // this means that the argument is required.
-    while ((opt = getopt_long(argc, argv, "o:s:p:f:rndclh", long_options, NULL)) != -1) {
+    while ((opt = getopt_long(argc, argv, "o:s:p:f:b:P:t:rndclh", long_options, NULL)) != -1) {
         int32_t temporary;
         switch (opt) {
             case 0:
@@ -97,6 +132,35 @@ int main(const int argc, char* const argv[]) {
 
                 fprintf(stderr, "Invalid pixel format specified: --pixel_format = %s\n", optarg);
                 exit(EXIT_FAILURE);
+
+            case 'b':
+                capture_settings.backend = string_to_backend(optarg);
+                if (capture_settings.backend != -1) break;
+
+                fprintf(stderr, "Invalid backend specified: --backend = %s "
+                                "(allowed: auto, x11, pipewire, direct)\n", optarg);
+                exit(EXIT_FAILURE);
+
+            case 'P':
+                temporary = atoi(optarg);
+                if (temporary <= 0) {
+                    fprintf(stderr, "Invalid pid specified: --pid = %s\n", optarg);
+                    exit(EXIT_FAILURE);
+                }
+                capture_settings.vulkan_pid = (uint32_t) temporary;
+                break;
+
+            case 't':
+                capture_settings.vulkan_target_index = (uint32_t) atoi(optarg);
+                break;
+
+            case OPT_PORTAL_TOKEN:
+                capture_settings.xdg_portal_token_path = optarg;
+                break;
+
+            case OPT_NEW_TOKEN:
+                capture_settings.issue_new_xdg_token = true;
+                break;
 
             case 'n':
                 capture_settings.push_model = false;
@@ -129,7 +193,16 @@ int main(const int argc, char* const argv[]) {
         }
     }
 
-    if (output_device == -1) {
+    // A target process implies the direct backend.
+    if (capture_settings.vulkan_pid != 0 && capture_settings.backend != NVFBC_BACKEND_DIRECT) {
+        if (capture_settings.backend != NVFBC_BACKEND_AUTO) {
+            fprintf(stderr, "Note: --pid implies the direct backend; overriding the requested backend.\n");
+        }
+        capture_settings.backend = NVFBC_BACKEND_DIRECT;
+    }
+
+    // An output device is only required when actually capturing to a v4l2 device.
+    if (!list && !stdout_output && output_device == -1) {
         fprintf(stderr,"Error: Required argument \'output-device\' not specified.\n");
         fprintf(stderr,"To see all available arguments use the -h or --help arguments.\n");
         exit(EXIT_FAILURE);
@@ -140,12 +213,42 @@ int main(const int argc, char* const argv[]) {
     byte *frame;
     void **frame_ptr = (void **) &frame;
 
-    NvFBC_InitData nvfbc_data = load_libraries();
-    const X_Data x_data = get_screens(nvfbc_data.X_display);
+    const NVFBC_BACKEND backend = resolve_backend(capture_settings.backend);
+    capture_settings.backend = backend;
+    fprintf(stderr,"Backend: %s\n", backend_name(backend));
 
-    if (list == true) {
-        list_screens(x_data);
-        exit(EXIT_SUCCESS);
+    // PipeWire reuses a saved portal token (unless overridden) to skip the dialog.
+    if (capture_settings.xdg_portal_token_path == NULL) {
+        capture_settings.xdg_portal_token_path = default_portal_token_path();
+    }
+
+    NvFBC_InitData nvfbc_data = load_libraries(backend);
+
+    // Per-backend display querying and --list-screens handling.
+    X_Data x_data = { .screens = NULL, .count = 0 };
+
+    if (backend == NVFBC_BACKEND_X11) {
+        x_data = get_screens(nvfbc_data.X_display);
+        if (list) {
+            list_screens(x_data);
+            exit(EXIT_SUCCESS);
+        }
+    } else if (backend == NVFBC_BACKEND_PIPEWIRE) {
+        if (list) {
+            fprintf(stderr, "On the PipeWire (Wayland) backend the screen is chosen through the\n"
+                            "compositor's screen-picker dialog when capture starts, so there is\n"
+                            "nothing to list here.\n");
+            exit(EXIT_SUCCESS);
+        }
+    } else { // NVFBC_BACKEND_DIRECT
+        if (capture_settings.vulkan_pid == 0) {
+            fprintf(stderr, "The direct backend requires a target process. Pass --pid <pid>.\n");
+            exit(EXIT_FAILURE);
+        }
+        if (list) {
+            list_direct_targets(capture_settings.vulkan_pid);
+            exit(EXIT_SUCCESS);
+        }
     }
 
     if (stdout_output) {
@@ -153,9 +256,11 @@ int main(const int argc, char* const argv[]) {
     }
     else fprintf(stderr,"Output device: /dev/video%u\n", output_device);
 
-    fprintf(stderr,"Screen: %i\n", capture_settings.screen);
+    // X11: optionally track a specific RandR output. (screen == -1 captures the
+    // whole framebuffer.)
+    if (backend == NVFBC_BACKEND_X11 && capture_settings.screen != -1) {
+        fprintf(stderr,"Screen: %i\n", capture_settings.screen);
 
-    if (capture_settings.screen != -1) {
         if (capture_settings.screen >= x_data.count) {
             fprintf(stderr, "Requested screen index is bigger than the display count.\n");
             exit(EXIT_FAILURE);
@@ -172,26 +277,38 @@ int main(const int argc, char* const argv[]) {
     }
 
     const NvFBC_SessionData nvfbc_session = create_session(nvfbc_data, capture_settings, frame_ptr, pixel_fmt);
-    if (!stdout_output) fprintf(stderr,"Opening the V4L2 loopback device.\n");
+    const NvFBC_SessionData* session_pointer = &nvfbc_session;
+
+    fprintf(stderr,"Starting capture. Press CTRL+C to exit. \n");
+
+    // Grab a first frame to learn the real capture dimensions. The PipeWire and
+    // direct backends cannot report the frame size before a session exists, so we
+    // size the v4l2 device from the actual frame instead of a pre-queried screen.
+    NVFBC_FRAME_GRAB_INFO frame_info;
+    const uint32_t timeout = (uint32_t) lround(1000.0 / capture_settings.fps);
+    capture_frame(session_pointer, timeout, &frame_info);
+
+    const uint32_t width = frame_info.dwWidth;
+    const uint32_t height = frame_info.dwHeight;
+    fprintf(stderr,"Capture size: %ux%u\n", width, height);
 
     int32_t file_descriptor;
     if (stdout_output) file_descriptor = fileno(stdout);
     else {
+        fprintf(stderr,"Opening the V4L2 loopback device.\n");
         file_descriptor = open_device(output_device);
-        set_device_format(file_descriptor, nvfbc_data.width, nvfbc_data.height, pixel_fmt, capture_settings.fps);
+        set_device_format(file_descriptor, width, height, pixel_fmt, capture_settings.fps);
     }
 
-    fprintf(stderr,"Starting capture. Press CTRL+C to exit. \n");
-    const uint32_t buffer_size = get_pixel_buffer_size(nvfbc_data.width, nvfbc_data.height, pixel_fmt);
+    const uint32_t buffer_size = get_pixel_buffer_size(width, height, pixel_fmt);
 
-    const NvFBC_SessionData* session_pointer = &nvfbc_session;
     signal(SIGINT, interrupt_signal);
 
     YUV_420_Data* yuv_data = NULL;
     if (pixel_fmt == YUV_420) {
         yuv_data = malloc(sizeof(YUV_420_Data));
         memset(yuv_data, 0, sizeof(YUV_420_Data));
-        yuv420_loop(frame_ptr, nvfbc_data, file_descriptor, buffer_size, session_pointer, &yuv_data, &capture_settings);
+        yuv420_loop(frame_ptr, width, height, file_descriptor, buffer_size, session_pointer, &yuv_data, &capture_settings);
     }
     else normal_loop(frame_ptr, file_descriptor, buffer_size, session_pointer, &capture_settings);
 
@@ -204,37 +321,46 @@ int main(const int argc, char* const argv[]) {
     return EXIT_SUCCESS;
 }
 
-void yuv420_loop(void** frame_ptr, const NvFBC_InitData nvfbc_data, const int32_t v4l2_device,
-              const uint32_t buffer_size, const NvFBC_SessionData* session_pointer, YUV_420_Data** yuv_data, Capture_Settings* capture_settings) {
-    uint32_t timeout = (uint32_t) lround(1000.0 / capture_settings->fps);
+void yuv420_loop(void** frame_ptr, const uint32_t width, const uint32_t height, const int32_t v4l2_device,
+              const uint32_t buffer_size, const NvFBC_SessionData* session_pointer, YUV_420_Data** yuv_data, const Capture_Settings* capture_settings) {
+    const uint32_t timeout = (uint32_t) lround(1000.0 / capture_settings->fps);
+    NVFBC_FRAME_GRAB_INFO frame_info;
 
     while (quit_program != true) {
-        capture_frame(session_pointer, timeout);
-        inplace_nv12_to_yuv420p(*frame_ptr, nvfbc_data.width, nvfbc_data.height, *yuv_data);
-        write_frame(v4l2_device, frame_ptr, buffer_size);
+        capture_frame(session_pointer, timeout, &frame_info);
+        inplace_nv12_to_yuv420p(*frame_ptr, width, height, *yuv_data);
+        const uint32_t write_size = frame_info.dwByteSize != 0 ? frame_info.dwByteSize : buffer_size;
+        write_frame(v4l2_device, frame_ptr, write_size);
     }
 }
 
-void normal_loop(void** frame_ptr, const int32_t v4l2_device, const uint32_t buffer_size, const NvFBC_SessionData* session_pointer, Capture_Settings* capture_settings) {
-    uint32_t timeout = (uint32_t) lround(1000.0 / capture_settings->fps);
+void normal_loop(void** frame_ptr, const int32_t v4l2_device, const uint32_t buffer_size, const NvFBC_SessionData* session_pointer, const Capture_Settings* capture_settings) {
+    const uint32_t timeout = (uint32_t) lround(1000.0 / capture_settings->fps);
+    NVFBC_FRAME_GRAB_INFO frame_info;
 
     while (quit_program != true) {
-        capture_frame(session_pointer, timeout);
-        write_frame(v4l2_device, frame_ptr, buffer_size);
+        capture_frame(session_pointer, timeout, &frame_info);
+        const uint32_t write_size = frame_info.dwByteSize != 0 ? frame_info.dwByteSize : buffer_size;
+        write_frame(v4l2_device, frame_ptr, write_size);
     }
 }
 
 void show_help() {
     fprintf(stderr, "Usage: nvfbc-v4l2 [options]\n");
     fprintf(stderr,"Options:\n");
-    fprintf(stderr,"  -o, --output-device <device>  REQUIRED: Sets the V4L2 output device number.\n");
-    fprintf(stderr,"  -s, --screen <screen>         Sets the requested X screen.\n");
+    fprintf(stderr,"  -o, --output-device <device>  REQUIRED (unless --stdout/--list-screens): V4L2 output device number.\n");
+    fprintf(stderr,"  -b, --backend <backend>       Capture backend: 'auto' (Default), 'x11', 'pipewire', 'direct'.\n");
+    fprintf(stderr,"  -s, --screen <screen>         X11 backend: requested RandR output (-1 = whole framebuffer).\n");
+    fprintf(stderr,"  -P, --pid <pid>               Direct backend: pid of the Vulkan application to capture (implies --backend direct).\n");
+    fprintf(stderr,"  -t, --target <index>          Direct backend: index of the capture target (Default: 0).\n");
+    fprintf(stderr,"      --portal-token <path>     PipeWire backend: XDG portal restore token file (Default: ~/.cache/nvfbc-v4l2/portal.token).\n");
+    fprintf(stderr,"      --new-token               PipeWire backend: force a fresh portal session (shows the picker again) and replace the saved token.\n");
     fprintf(stderr,"  -p, --pixel_format <pix_fmt>  Sets the wanted pixel format. Allowed values: 'rgb' (Default), 'yuv420', 'rgba', 'nv12'\n");
     fprintf(stderr,"  -f, --fps <fps>               Sets the frames per second.\n");
     fprintf(stderr,"  -r, --stdout                  Write the raw video data to stdout instead of a v4l2 device.\n");
     fprintf(stderr,"  -n, --no-push-model           Disables push model.\n");
     fprintf(stderr,"  -d, --direct-capture          Enables direct capture. (warning: causes cursor issues when a screen is selected)\n");
     fprintf(stderr,"  -c, --no-cursor               Hides the cursor.\n");
-    fprintf(stderr,"  -l, --list-screens            Lists available screens.\n");
+    fprintf(stderr,"  -l, --list-screens            Lists available screens (or, with --pid, direct capture targets).\n");
     fprintf(stderr,"  -h, --help                    Shows this help message.\n");
 }

--- a/nvfbc_v4l2.c
+++ b/nvfbc_v4l2.c
@@ -1,7 +1,93 @@
 #include "nvfbc_v4l2.h"
 #include <string.h>
+#include <stdio.h>
+#include <sys/stat.h>
+#include <math.h>
+#include <dlfcn.h>
+#include <pthread.h>
 
-NvFBC_InitData load_libraries() {
+NVFBC_BACKEND resolve_backend(const NVFBC_BACKEND requested) {
+    if (requested != NVFBC_BACKEND_AUTO) {
+        return requested;
+    }
+
+    const char *session_type = getenv("XDG_SESSION_TYPE");
+    if (session_type != NULL && strcmp(session_type, "wayland") == 0) {
+        return NVFBC_BACKEND_PIPEWIRE;
+    }
+    if (getenv("DISPLAY") != NULL) {
+        return NVFBC_BACKEND_X11;
+    }
+    return NVFBC_BACKEND_DIRECT;
+}
+
+const char *default_portal_token_path(void) {
+    static char path[4096];
+
+    const char *cache = getenv("XDG_CACHE_HOME");
+    if (cache != NULL && cache[0] != '\0') {
+        snprintf(path, sizeof(path), "%s/nvfbc-v4l2/portal.token", cache);
+        return path;
+    }
+
+    const char *home = getenv("HOME");
+    if (home == NULL || home[0] == '\0') {
+        return NULL;
+    }
+    snprintf(path, sizeof(path), "%s/.cache/nvfbc-v4l2/portal.token", home);
+    return path;
+}
+
+static bool load_portal_token(const char *path, char *token_out) {
+    FILE *file = fopen(path, "rb");
+    if (file == NULL) {
+        return false;
+    }
+
+    const size_t read = fread(token_out, 1, NVFBC_PORTAL_RESTORE_TOKEN_LEN - 1, file);
+    fclose(file);
+    if (read == 0) {
+        return false;
+    }
+
+    token_out[read] = '\0';
+    char *newline = strchr(token_out, '\n');
+    if (newline != NULL) {
+        *newline = '\0';
+    }
+    return true;
+}
+
+
+static void basic_mkdir_p(const char *path) {
+    char tmp[4096];
+    snprintf(tmp, sizeof(tmp), "%s", path);
+
+    for (char *p = tmp + 1; *p != '\0'; ++p) {
+        if (*p == '/') {
+            *p = '\0';
+            mkdir(tmp, 0755);
+            *p = '/';
+        }
+    }
+}
+
+static void save_portal_token(const char *path, const char *token) {
+    basic_mkdir_p(path);
+
+    FILE *file = fopen(path, "wb");
+    if (file == NULL) {
+        fprintf(stderr, "Warning: could not write portal restore token to '%s'.\n", path);
+        return;
+    }
+
+    fputs(token, file);
+    fputc('\n', file);
+    fclose(file);
+    fprintf(stderr, "Saved XDG portal restore token to '%s'.\n", path);
+}
+
+NvFBC_InitData load_libraries(const NVFBC_BACKEND backend) {
     Display *dpy = NULL;
 
     nvfbc_lib = dlopen(NVFBC_LIB_NAME, RTLD_NOW);
@@ -26,28 +112,109 @@ NvFBC_InitData load_libraries() {
         exit(EXIT_FAILURE);
     }
 
-    dpy = XOpenDisplay(NULL);
-    if (dpy == NULL) {
-        fprintf(stderr, "Unable to open X11 display. \n");
+    uint32_t framebuffer_width = 0;
+    uint32_t framebuffer_height = 0;
+
+    if (backend == NVFBC_BACKEND_X11) {
+        dpy = XOpenDisplay(NULL); // display is only needed on X11
+        if (dpy == NULL) {
+            fprintf(stderr, "Unable to open X11 display. \n");
+            exit(EXIT_FAILURE);
+        }
+
+        framebuffer_width = DisplayWidth(dpy, XDefaultScreen(dpy));
+        framebuffer_height = DisplayHeight(dpy, XDefaultScreen(dpy));
+    }
+
+    const NvFBC_InitData result = {
+        .X_display = dpy,
+        .width = framebuffer_width,
+        .height = framebuffer_height
+    };
+    return result;
+}
+
+static NVFBCSTATUS create_nvfbc_handle(NVFBC_SESSION_HANDLE *handle,
+                                       NVFBC_CREATE_HANDLE_PARAMS *params,
+                                       const NVFBC_BACKEND backend,
+                                       const char *portal_token_path,
+                                       const bool force_new_xdg_token) {
+    memset(params, 0, sizeof(*params));
+    params->dwVersion = NVFBC_CREATE_HANDLE_PARAMS_VER;
+    params->eBackend = backend;
+    params->bUseEGL = backend != NVFBC_BACKEND_X11 ? NVFBC_TRUE : NVFBC_FALSE;
+
+    if (backend == NVFBC_BACKEND_PIPEWIRE) {
+        if (force_new_xdg_token) {
+            fprintf(stderr, "Forcing a new portal session (ignoring any saved restore token).\n");
+        } else if (portal_token_path != NULL &&
+                   load_portal_token(portal_token_path, params->portalRestoreToken)) {
+            fprintf(stderr, "Loaded XDG portal restore token from '%s'.\n", portal_token_path);
+        }
+    }
+
+    NVFBCSTATUS nvfbc_status = function_list.nvFBCCreateHandle(handle, params);
+    if (nvfbc_status != NVFBC_SUCCESS) {
+        fprintf(stderr, "Failed to create a NvFBC handle normally (%i), trying with interop key. \n",
+                nvfbc_status);
+        static const uint8_t enable_key[] = {
+            0xac, 0x10, 0xc9, 0x2e, 0xa5, 0xe6,
+            0x87, 0x4f, 0x8f, 0x4b, 0xf4, 0x61,
+            0xf8, 0x56, 0x27, 0xe9
+        };
+        params->privateData = enable_key;
+        params->privateDataSize = 16;
+
+        nvfbc_status = function_list.nvFBCCreateHandle(handle, params);
+    }
+
+    return nvfbc_status;
+}
+
+void list_direct_targets(const uint32_t pid) {
+    NVFBC_SESSION_HANDLE fbc_handle;
+    NVFBC_CREATE_HANDLE_PARAMS create_handle_params;
+
+    NVFBCSTATUS nvfbc_status = create_nvfbc_handle(&fbc_handle, &create_handle_params,
+                                                   NVFBC_BACKEND_DIRECT, NULL, false);
+    if (nvfbc_status != NVFBC_SUCCESS) {
+        fprintf(stderr, "Failed to create a NvFBC handle for the direct backend: '%s'.\n",
+                function_list.nvFBCGetLastErrorStr(fbc_handle));
         exit(EXIT_FAILURE);
     }
 
-    const uint32_t framebuffer_width = DisplayWidth(dpy, XDefaultScreen(dpy));
-    const uint32_t framebuffer_height = DisplayHeight(dpy, XDefaultScreen(dpy));
+    NVFBC_GET_STATUS_PARAMS status_params = {0};
+    status_params.dwVersion = NVFBC_GET_STATUS_PARAMS_VER;
+    status_params.dwPid = pid;
+    status_params.dwDbusTimeoutMs = 1000;
 
-    const NvFBC_InitData result = {
-            .X_display = dpy,
+    nvfbc_status = function_list.nvFBCGetStatus(fbc_handle, &status_params);
+    if (nvfbc_status != NVFBC_SUCCESS) {
+        fprintf(stderr, "Failed to query direct capture targets for pid %u: '%s'.\n",
+                pid, function_list.nvFBCGetLastErrorStr(fbc_handle));
+        exit(EXIT_FAILURE);
+    }
 
-            // Replaced if screen is specified.
-            .width = framebuffer_width,
-            .height = framebuffer_height
-    };
-    return result;
+    if (status_params.dwCaptureTargetCount == 0) {
+        fprintf(stderr, "No capture targets found for pid %u. Is it a running Vulkan application?\n", pid);
+    } else {
+        fprintf(stderr, "Capture targets for pid %u:\n", pid);
+        for (uint32_t i = 0; i < status_params.dwCaptureTargetCount; ++i) {
+            fprintf(stderr, "  Target %u: %ux%u\n", i,
+                    status_params.captureTargetSizes[i].w,
+                    status_params.captureTargetSizes[i].h);
+        }
+    }
+
+    NVFBC_DESTROY_HANDLE_PARAMS destroy_handle_params = {0};
+    destroy_handle_params.dwVersion = NVFBC_DESTROY_HANDLE_PARAMS_VER;
+    function_list.nvFBCDestroyHandle(fbc_handle, &destroy_handle_params);
 }
 
 NvFBC_SessionData create_session(NvFBC_InitData init_data, Capture_Settings capture_settings, void **frame_ptr,
                                  enum Pixel_Format pixel_fmt) {
     NVFBCSTATUS nvfbc_status;
+    const NVFBC_BACKEND backend = capture_settings.backend;
 
     NVFBC_SESSION_HANDLE fbc_handle;
     NVFBC_CREATE_HANDLE_PARAMS create_handle_params;
@@ -55,45 +222,22 @@ NvFBC_SessionData create_session(NvFBC_InitData init_data, Capture_Settings capt
     NVFBC_CREATE_CAPTURE_SESSION_PARAMS create_capture_params;
     NVFBC_TOSYS_SETUP_PARAMS setup_params;
 
-    NVFBC_BOX capture_box = {
-            .x = 0,
-            .y = 0,
-
-            .w = init_data.width,
-            .h = init_data.height
-    };
-
-    NVFBC_SIZE capture_size = {
-            .w = init_data.width,
-            .h = init_data.height
-    };
-
     // Create new session handle.
-    memset(&create_handle_params, 0, sizeof(create_handle_params));
-    create_handle_params.dwVersion = NVFBC_CREATE_HANDLE_PARAMS_VER;
-
-    nvfbc_status = function_list.nvFBCCreateHandle(&fbc_handle, &create_handle_params);
-    if (nvfbc_status != NVFBC_SUCCESS) {
-        fprintf(stderr, "Failed to create a NvFBC handle normally (%i), trying with interop key. \n",
-                nvfbc_status);
-        const uint8_t enable_key[] = {0xac, 0x10, 0xc9, 0x2e, 0xa5, 0xe6,
-                                      0x87, 0x4f,0x8f,0x4b, 0xf4, 0x61,
-                                      0xf8,0x56, 0x27, 0xe9};
-        create_handle_params.privateData = enable_key;
-        create_handle_params.privateDataSize = 16;
-
-        nvfbc_status = function_list.nvFBCCreateHandle(&fbc_handle, &create_handle_params);
-    }
-
+    nvfbc_status = create_nvfbc_handle(&fbc_handle, &create_handle_params, backend,
+                                       capture_settings.xdg_portal_token_path, capture_settings.issue_new_xdg_token);
     if (nvfbc_status != NVFBC_SUCCESS) {
         fprintf(stderr, "Failed to create a NvFBC handle with the following error type: '%i', and error message '%s'. "
-                        "Exiting. \n", nvfbc_status, function_list.nvFBCGetLastErrorStr(fbc_handle));
+                "Exiting. \n", nvfbc_status, function_list.nvFBCGetLastErrorStr(fbc_handle));
         exit(EXIT_FAILURE);
     }
 
     // Get display driver state.
     memset(&status_params, 0, sizeof(status_params));
     status_params.dwVersion = NVFBC_GET_STATUS_PARAMS_VER;
+    if (backend == NVFBC_BACKEND_DIRECT) {
+        status_params.dwPid = capture_settings.vulkan_pid;
+        status_params.dwDbusTimeoutMs = 1000;
+    }
 
     nvfbc_status = function_list.nvFBCGetStatus(fbc_handle, &status_params);
     if (nvfbc_status != NVFBC_SUCCESS) {
@@ -107,21 +251,64 @@ NvFBC_SessionData create_session(NvFBC_InitData init_data, Capture_Settings capt
         exit(EXIT_FAILURE);
     }
 
+    if (backend == NVFBC_BACKEND_DIRECT) {
+        if (status_params.dwCaptureTargetCount == 0) {
+            fprintf(stderr, "No capture targets found for pid %u. Is it a running Vulkan application?\n",
+                    capture_settings.vulkan_pid);
+            exit(EXIT_FAILURE);
+        }
+        if (capture_settings.vulkan_target_index >= status_params.dwCaptureTargetCount) {
+            fprintf(stderr, "Requested capture target %u is out of range (found %u targets).\n",
+                    capture_settings.vulkan_target_index, status_params.dwCaptureTargetCount);
+            exit(EXIT_FAILURE);
+        }
+    }
+
     // Create a capture session that captures to system memory.
     memset(&create_capture_params, 0, sizeof(create_capture_params));
-
     create_capture_params.dwVersion = NVFBC_CREATE_CAPTURE_SESSION_PARAMS_VER;
     create_capture_params.eCaptureType = NVFBC_CAPTURE_TO_SYS;
-    create_capture_params.captureBox = capture_box;
-    create_capture_params.frameSize = capture_size;
-
     create_capture_params.bRoundFrameSize = NVFBC_FALSE;
-    create_capture_params.dwOutputId = init_data.display_id;
-    create_capture_params.eTrackingType = capture_settings.screen == -1 ? NVFBC_TRACKING_SCREEN : NVFBC_TRACKING_OUTPUT;
     create_capture_params.bWithCursor = capture_settings.show_cursor ? NVFBC_TRUE : NVFBC_FALSE;
-    create_capture_params.bPushModel = capture_settings.push_model ? NVFBC_TRUE : NVFBC_FALSE;
-    create_capture_params.bAllowDirectCapture = capture_settings.direct_capture ? NVFBC_TRUE : NVFBC_FALSE;
     create_capture_params.dwSamplingRateMs = (int) lround(1000.0 / capture_settings.fps);
+
+    switch (backend) {
+        case NVFBC_BACKEND_AUTO:
+            fprintf(stderr, "Auto backend should already be decided, but has reached create_capture_params. \n");
+            exit(EXIT_FAILURE);
+        case NVFBC_BACKEND_X11:
+            const NVFBC_BOX capture_box = {
+                .x = 0,
+                .y = 0,
+                .w = init_data.width,
+                .h = init_data.height
+            };
+            const NVFBC_SIZE capture_size = {
+                .w = init_data.width,
+                .h = init_data.height
+            };
+
+            create_capture_params.captureBox = capture_box;
+            create_capture_params.frameSize = capture_size;
+            create_capture_params.dwOutputId = init_data.display_id;
+            create_capture_params.eTrackingType =
+                    capture_settings.screen == -1 ? NVFBC_TRACKING_SCREEN : NVFBC_TRACKING_OUTPUT;
+            create_capture_params.bPushModel = capture_settings.push_model ? NVFBC_TRUE : NVFBC_FALSE;
+            create_capture_params.bAllowDirectCapture = capture_settings.direct_capture ? NVFBC_TRUE : NVFBC_FALSE;
+            break;
+        case NVFBC_BACKEND_PIPEWIRE:
+            create_capture_params.eTrackingType = NVFBC_TRACKING_DEFAULT;
+            create_capture_params.bPushModel = NVFBC_FALSE;
+            break;
+        case NVFBC_BACKEND_DIRECT:
+            create_capture_params.eTrackingType = NVFBC_TRACKING_DEFAULT;
+            create_capture_params.bPushModel = NVFBC_TRUE;
+            create_capture_params.bWithCursor = NVFBC_FALSE;
+            create_capture_params.dwPid = capture_settings.vulkan_pid;
+            create_capture_params.dwCaptureTarget = capture_settings.vulkan_target_index;
+            create_capture_params.dwDbusTimeoutMs = 1000;
+            break;
+    }
 
     nvfbc_status = function_list.nvFBCCreateCaptureSession(fbc_handle, &create_capture_params);
     if (nvfbc_status != NVFBC_SUCCESS) {
@@ -142,11 +329,21 @@ NvFBC_SessionData create_session(NvFBC_InitData init_data, Capture_Settings capt
         exit(EXIT_FAILURE);
     }
 
+    if (backend == NVFBC_BACKEND_PIPEWIRE && capture_settings.xdg_portal_token_path != NULL) {
+        NVFBC_GET_STATUS_PARAMS token_status = {0};
+        token_status.dwVersion = NVFBC_GET_STATUS_PARAMS_VER;
+
+        if (function_list.nvFBCGetStatus(fbc_handle, &token_status) == NVFBC_SUCCESS &&
+            token_status.portalRestoreToken[0] != '\0') {
+            save_portal_token(capture_settings.xdg_portal_token_path, token_status.portalRestoreToken);
+        }
+    }
+
     NvFBC_SessionData result = {
-            .create_capture_params = create_capture_params,
-            .create_handle_params = create_handle_params,
-            .fbc_handle = fbc_handle,
-            .status_params = status_params
+        .create_capture_params = create_capture_params,
+        .create_handle_params = create_handle_params,
+        .fbc_handle = fbc_handle,
+        .status_params = status_params
     };
     return result;
 }
@@ -160,7 +357,7 @@ void destroy_session(const NvFBC_SessionData session_data) {
     destroy_capture_params.dwVersion = NVFBC_DESTROY_CAPTURE_SESSION_PARAMS_VER;
 
     NVFBCSTATUS nvfbc_status = function_list.nvFBCDestroyCaptureSession(
-            session_data.fbc_handle, &destroy_capture_params);
+        session_data.fbc_handle, &destroy_capture_params);
     if (nvfbc_status != NVFBC_SUCCESS) {
         fprintf(stderr, "%s\n", function_list.nvFBCGetLastErrorStr(session_data.fbc_handle));
         exit(EXIT_FAILURE);
@@ -177,12 +374,10 @@ void destroy_session(const NvFBC_SessionData session_data) {
     }
 }
 
-void capture_frame(const NvFBC_SessionData *session_data, u_int32_t timeout_ms) {
-    NVFBC_TOSYS_GRAB_FRAME_PARAMS grab_params;
-    NVFBC_FRAME_GRAB_INFO frame_info;
+void capture_frame(const NvFBC_SessionData *session_data, const uint32_t timeout_ms, NVFBC_FRAME_GRAB_INFO *frame_info) {
+    NVFBC_TOSYS_GRAB_FRAME_PARAMS grab_params = {0};
 
-    memset(&grab_params, 0, sizeof(grab_params));
-    memset(&frame_info, 0, sizeof(frame_info));
+    memset(frame_info, 0, sizeof(*frame_info));
 
     grab_params.dwVersion = NVFBC_TOSYS_GRAB_FRAME_PARAMS_VER;
 
@@ -192,8 +387,8 @@ void capture_frame(const NvFBC_SessionData *session_data, u_int32_t timeout_ms) 
     // Sets the timeout to the current capture framerate.
     grab_params.dwTimeoutMs = timeout_ms;
 
-    // Frame info.
-    grab_params.pFrameGrabInfo = &frame_info;
+    // Frame info, including the real dimensions and byte size of the grabbed frame.
+    grab_params.pFrameGrabInfo = frame_info;
 
     // Captures a frame.
     const NVFBCSTATUS nvfbc_status = function_list.nvFBCToSysGrabFrame(session_data->fbc_handle, &grab_params);

--- a/nvfbc_v4l2.h
+++ b/nvfbc_v4l2.h
@@ -2,10 +2,7 @@
 #define NVFBC_V4L2
 
 #include <stdint.h>
-#include <pthread.h>
 #include <malloc.h>
-#include <math.h>
-#include <dlfcn.h>
 #include <stdlib.h>
 
 #include <X11/Xlib.h>
@@ -19,6 +16,12 @@ typedef struct {
     int32_t fps;
     bool push_model;
     bool direct_capture;
+
+    NVFBC_BACKEND backend;
+    uint32_t vulkan_pid;
+    uint32_t vulkan_target_index;
+    const char *xdg_portal_token_path;
+    bool issue_new_xdg_token;
 } Capture_Settings;
 
 typedef struct {
@@ -61,12 +64,20 @@ static enum _NVFBC_BUFFER_FORMAT get_nvfbc_pixel_format(const enum Pixel_Format 
     }
 }
 
-NvFBC_InitData load_libraries();
+
+NVFBC_BACKEND resolve_backend(NVFBC_BACKEND requested);
+
+const char *default_portal_token_path(void);
+
+void list_direct_targets(uint32_t pid);
+
+NvFBC_InitData load_libraries(NVFBC_BACKEND backend);
 
 NvFBC_SessionData
-create_session(NvFBC_InitData init_data, Capture_Settings capture_settings, void **frame_ptr, enum Pixel_Format pixel_fmt);
+create_session(NvFBC_InitData init_data, Capture_Settings capture_settings, void **frame_ptr,
+               enum Pixel_Format pixel_fmt);
 
-void capture_frame(const NvFBC_SessionData *session_data, uint32_t timeout_ms);
+void capture_frame(const NvFBC_SessionData *session_data, uint32_t timeout_ms, NVFBC_FRAME_GRAB_INFO *frame_info);
 
 void destroy_session(NvFBC_SessionData session_data);
 


### PR DESCRIPTION
Implements #16 — migrates nvfbc-v4l2 to NVIDIA Capture SDK 9.0 / NVFBC 1.9 with selectable capture backends.

## What's new
- **Backend selection** (`--backend auto|x11|pipewire|direct`, auto-detected from the session). `load_libraries()` no longer hard-requires X11, so PipeWire and Direct init without an X display.
- **Wayland capture** via the PipeWire backend (EGL, no X); the compositor's XDG Desktop Portal picks the screen.
- **portalRestoreToken**: saved to `~/.cache/nvfbc-v4l2/portal.token` (override `--portal-token`) and reused to skip the picker dialog. `--new-token` forces a fresh session and replaces the saved token.
- **Direct/Vulkan capture by pid** (`--pid`/`--target`) with capture-target enumeration.
- **Deferred v4l2 sizing**: device format derives from the first frame's `NVFBC_FRAME_GRAB_INFO` (required for PipeWire, correct for all backends); write size uses `dwByteSize`.

No new build/link deps — NvFBC `dlopen`s libpipewire/libdbus/libdrm itself.

Closes #16.